### PR TITLE
Implemented crossover at 80hz to switch to non convolution bass to lower THD and clean up spectral delay in bass

### DIFF
--- a/JBL M2 Binaural Convolution/Binaural Convolution - JBL LSR305 at DRP w Channel EQ.txt
+++ b/JBL M2 Binaural Convolution/Binaural Convolution - JBL LSR305 at DRP w Channel EQ.txt
@@ -2,19 +2,28 @@
 # Copy: R=0*R
 Channel: L
 Channel: all
-Copy: LL=L LR=L RL=R RR=R
+Copy: LL=L LR=L RL=R RR=R LLLOW=L LRLOW=L RLLOW=R RRLOW=R
 Channel: LL LR
 Convolution: IRs\JBL LSR305 LL 4_LR 4.wav
-Channel: LR
+Channel: LR LRLOW
 Delay: 0.09 ms
 Channel: RL RR
 Convolution: IRs\JBL LSR305 RL 4_RR 4.wav
-Channel: RL
+Channel: RL RLLOW
 Delay: 0.09 ms
 Include: Channel Balance EQ.txt
 Include: EQ to JBL M2.txt
+Channel: LL LR RL RR
+Filter: ON HP Fc 80 Hz
+Channel: LLLOW LRLOW RLLOW RRLOW
+Filter: ON LP Fc 80 Hz
+Preamp: -15 dB
+Delay: 125 ms
 Channel: ALL
-Copy: L=LL+RL R=LR+RR
+Copy: L=LL+RL+LLLOW+RLLOW R=LR+RR+LRLOW+RRLOW
+# Next two lines for debug purposes
+# Copy: L=LL+RL R=LR+RR
+# Copy: L=LLLOW+RLLOW R=LRLOW+RRLOW
 # Oddly this significantly reduces the calculated latency in the EqualizerAPO editor analysis panel
 Filter: ON HS Fc 22400 Hz Gain 40 dB
 Filter: ON HS Fc 22400 Hz Gain 20 dB

--- a/JBL M2 Binaural Convolution/EQ to JBL M2.txt
+++ b/JBL M2 Binaural Convolution/EQ to JBL M2.txt
@@ -1,20 +1,21 @@
 # Adjustments to take the measurements for the JBL LSR305 and match them to the JBL M2
-Channel: all
+# Only adjust the channels that go through the binaural convolution
+Channel: LL LR RR RL
 Preamp: 2 dB
 Filter: ON HP Fc 15 Hz
 Filter: ON HP Fc 20 Hz
-Filter: ON LS Fc 20 Hz Gain 50 dB
-Filter: ON PK Fc 25 Hz Gain 10 dB Q 2
-Filter: ON PK Fc 31 Hz Gain 8 dB Q 4
-Filter: ON PK Fc 33 Hz Gain 6 dB Q 6
-Filter: ON PK Fc 38.5 Hz Gain -3 dB Q 15
-Filter: ON PK Fc 41 Hz Gain -7 dB Q 15
-Filter: ON PK Fc 44 Hz Gain 3 dB Q 15
+# Filter: ON LS Fc 20 Hz Gain 50 dB
+# Filter: ON PK Fc 25 Hz Gain 10 dB Q 2
+# Filter: ON PK Fc 31 Hz Gain 8 dB Q 4
+# Filter: ON PK Fc 33 Hz Gain 6 dB Q 6
+# Filter: ON PK Fc 38.5 Hz Gain -3 dB Q 15
+# Filter: ON PK Fc 41 Hz Gain -7 dB Q 15
+# Filter: ON PK Fc 44 Hz Gain 3 dB Q 15
 Filter: ON PK Fc 50 Hz Gain -10 dB Q 1
-Filter: ON PK Fc 57.4 Hz Gain 4 dB Q 10
-Filter: ON LS Fc 60 Hz Gain 4 dB
-Filter: ON PK Fc 80 Hz Gain 5 dB Q 10
-Filter: ON PK Fc 80.6 Hz Gain 4 dB Q 8
+# Filter: ON PK Fc 57.4 Hz Gain 4 dB Q 10
+# Filter: ON LS Fc 60 Hz Gain 4 dB
+# Filter: ON PK Fc 80 Hz Gain 5 dB Q 10
+# Filter: ON PK Fc 80.6 Hz Gain 4 dB Q 8
 Filter: ON LS Fc 100 Hz Gain -2 dB
 Filter: ON PK Fc 118 Hz Gain 3 dB Q 8
 Filter: ON PK Fc 121 Hz Gain 3 dB Q 10
@@ -44,5 +45,5 @@ Filter: ON PK Fc 13200 Hz Gain -3 dB Q 2
 Filter: ON PK Fc 15000 Hz Gain -3 dB Q 2
 # Adjustments for cross channel only
 Channel: LR RL
-Filter: ON PK Fc 26 Hz Gain 7 dB Q 3
+# Filter: ON PK Fc 26 Hz Gain 7 dB Q 3
 Channel: all

--- a/Target Curve Macro Adjustments.txt
+++ b/Target Curve Macro Adjustments.txt
@@ -2,4 +2,5 @@ Channel: all
 # Uncomment and adjust to tweak treble
 # Filter: ON HS Fc 4000 Hz Gain -1 dB
 # Uncomment and adjust to tweak bass
-# Filter: ON LS Fc 100 Hz Gain -1 dB
+Filter: ON LS Fc 100 Hz Gain -1 dB
+Filter: ON HP Fc 20 Hz


### PR DESCRIPTION
Upon making more measurements I discovered that the THD in the 20-30hz
range was in the 20% range and the bass at 26hz and below was delayed
around 325ms creating a noticable boominess. I belive this ultimately
was a result of heavily boosting the bass frequencies in the speaker IR
I recorded given that my JBL LSR305s drop off significantly below 40hz.

To clean this up I decided to cut away from the binaural convolution to
clean signal in the sub bass. Since bass frequencies are generally hard
to position audibly this works out nicely.

I found I had to remove all the bass boosting I did to my IR files to
make the crossover as clean as possible since I used a fairly gradual
crossover using the default Q factor.

Initially the cross over bass was playing about 125ms earlier then the
rest of the sounds causing odd comb filtering. This is the likely delay
of the convolution process even though I haven't found a way to formally
measure it accurately this number comes from spectral delay
measurements. After I implemented a delay to the clean signal the comb
filtering went away and the spectral delay now lines up cleanly.